### PR TITLE
Update to dbus 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,5 @@ name = "blurz"
 path = "src/lib.rs"
 
 [dependencies]
-dbus = "0.6"
+dbus = "0.9.0"
 hex = "0.4"

--- a/examples/test_advertising.rs
+++ b/examples/test_advertising.rs
@@ -4,7 +4,7 @@ extern crate dbus;
 use std::error::Error;
 use std::time::Duration;
 use std::thread;
-use dbus::MessageItem;
+use dbus::arg::messageitem::MessageItem;
 
 use blurz::bluetooth_adapter::BluetoothAdapter as Adapter;
 use blurz::bluetooth_device::BluetoothDevice as Device;
@@ -80,7 +80,7 @@ fn test_advertising() -> Result<(), Box<dyn Error>>{
     
     let manager = Manager::create_adv_manager()?;
     println!("{:?} : {:?}", manager, manager.get_conn());
-    manager.register_advertisement([addata.get_object_path().into(), MessageItem::DictEntry(Box::new(MessageItem::Byte(0)), Box::new(MessageItem::Byte(0)))])?;
+    manager.register_advertisement([addata.get_object_path().into(), MessageItem::new_dict(vec![(0u8.into(), 0u8.into())]).unwrap()])?;
 
     Ok(())
 }

--- a/src/bluetooth_adapter.rs
+++ b/src/bluetooth_adapter.rs
@@ -2,7 +2,8 @@ use crate::bluetooth_device::BluetoothDevice;
 use crate::bluetooth_le_advertising_data::BluetoothAdvertisingData;
 use crate::bluetooth_session::BluetoothSession;
 use crate::bluetooth_utils;
-use dbus::{Message, MessageItem, MessageItemArray, Signature};
+use dbus::Message;
+use dbus::arg::messageitem::MessageItem;
 use hex::FromHex;
 use std::error::Error;
 
@@ -294,21 +295,14 @@ impl<'a> BluetoothAdapter<'a> {
             AddressType::Random => "random",
         };
 
-        let mut m = vec![MessageItem::DictEntry(
-            Box::new("Address".into()),
-            Box::new(MessageItem::Variant(Box::new(address.into()))),
-        )];
-
-        m.push(MessageItem::DictEntry(
-            Box::new("AddressType".into()),
-            Box::new(MessageItem::Variant(Box::new(address_type.into()))),
-        ));
+        let m = MessageItem::new_dict(vec![
+            ("Address".into(), MessageItem::Variant(Box::new(address.into()))),
+            ("AddressType".into(), MessageItem::Variant(Box::new(address_type.into()))),
+        ]).unwrap();
 
         self.call_method(
             "ConnectDevice",
-            Some(&[MessageItem::Array(
-                MessageItemArray::new(m, Signature::from("a{sv}")).unwrap(),
-            )]),
+            Some(&[m]),
             timeout_ms,
         )
     }

--- a/src/bluetooth_device.rs
+++ b/src/bluetooth_device.rs
@@ -303,6 +303,12 @@ impl<'a> BluetoothDevice<'a> {
         Ok(m)
     }
 
+    // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n251
+    pub fn is_services_resolved(&self) -> Result<bool, Box<dyn Error>> {
+        let services_resolved = self.get_property("ServicesResolved")?;
+        Ok(services_resolved.inner::<bool>().unwrap())
+    }
+
     pub fn get_gatt_services(&self) -> Result<Vec<String>, Box<dyn Error>> {
         bluetooth_utils::list_services(self.session.get_connection(), &self.object_path)
     }

--- a/src/bluetooth_device.rs
+++ b/src/bluetooth_device.rs
@@ -1,7 +1,8 @@
 use crate::bluetooth_le_advertising_data::BluetoothAdvertisingData;
 use crate::bluetooth_session::BluetoothSession;
 use crate::bluetooth_utils;
-use dbus::{Message, MessageItem};
+use dbus::Message;
+use dbus::arg::messageitem::MessageItem;
 use hex::FromHex;
 use std::collections::HashMap;
 use std::error::Error;
@@ -266,10 +267,9 @@ impl<'a> BluetoothDevice<'a> {
         let manufacturer_data_array = self.get_property("ManufacturerData")?;
         let mut m = HashMap::new();
         let dict_vec = manufacturer_data_array
-            .inner::<&Vec<MessageItem>>()
+            .inner::<&[(MessageItem, MessageItem)]>()
             .unwrap();
-        for dict in dict_vec {
-            let (key, value) = dict.inner::<(&MessageItem, &MessageItem)>().unwrap();
+        for (key, value) in dict_vec {
             let v = value
                 .inner::<&MessageItem>()
                 .unwrap()
@@ -287,9 +287,8 @@ impl<'a> BluetoothDevice<'a> {
     pub fn get_service_data(&self) -> Result<HashMap<String, Vec<u8>>, Box<dyn Error>> {
         let service_data_array = self.get_property("ServiceData")?;
         let mut m = HashMap::new();
-        let dict_vec = service_data_array.inner::<&Vec<MessageItem>>().unwrap();
-        for dict in dict_vec {
-            let (key, value) = dict.inner::<(&MessageItem, &MessageItem)>().unwrap();
+        let dict_vec = service_data_array.inner::<&[(MessageItem, MessageItem)]>().unwrap();
+        for (key, value) in dict_vec {
             let v = value
                 .inner::<&MessageItem>()
                 .unwrap()

--- a/src/bluetooth_device.rs
+++ b/src/bluetooth_device.rs
@@ -181,7 +181,7 @@ impl<'a> BluetoothDevice<'a> {
         Ok(trusted.inner::<bool>().unwrap())
     }
 
-    // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n154
+    // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n185
     pub fn is_blocked(&self) -> Result<bool, Box<dyn Error>> {
         let blocked = self.get_property("Blocked")?;
         Ok(blocked.inner::<bool>().unwrap())
@@ -249,19 +249,19 @@ impl<'a> BluetoothDevice<'a> {
         Ok(device_id)
     }
 
-    // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n194
+    // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n230
     pub fn get_rssi(&self) -> Result<i16, Box<dyn Error>> {
         let rssi = self.get_property("RSSI")?;
         Ok(rssi.inner::<i16>().unwrap())
     }
 
-    // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n199
+    // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n235
     pub fn get_tx_power(&self) -> Result<i16, Box<dyn Error>> {
         let tx_power = self.get_property("TxPower")?;
         Ok(tx_power.inner::<i16>().unwrap())
     }
 
-    // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n204
+    // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n240
     pub fn get_manufacturer_data(&self) -> Result<HashMap<u16, Vec<u8>>, Box<dyn Error>> {
         let manufacturer_data_array = self.get_property("ManufacturerData")?;
         let mut m = HashMap::new();
@@ -283,7 +283,7 @@ impl<'a> BluetoothDevice<'a> {
         Ok(m)
     }
 
-    // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n210
+    // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n246
     pub fn get_service_data(&self) -> Result<HashMap<String, Vec<u8>>, Box<dyn Error>> {
         let service_data_array = self.get_property("ServiceData")?;
         let mut m = HashMap::new();
@@ -303,7 +303,6 @@ impl<'a> BluetoothDevice<'a> {
         Ok(m)
     }
 
-    // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n215
     pub fn get_gatt_services(&self) -> Result<Vec<String>, Box<dyn Error>> {
         bluetooth_utils::list_services(self.session.get_connection(), &self.object_path)
     }
@@ -317,27 +316,27 @@ impl<'a> BluetoothDevice<'a> {
         self.call_method("Connect", None, timeout_ms)
     }
 
-    // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n29
+    // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n43
     pub fn disconnect(&self) -> Result<Message, Box<dyn Error>> {
         self.call_method("Disconnect", None, 5000)
     }
 
-    // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n43
+    // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n61
     pub fn connect_profile(&self, uuid: String) -> Result<Message, Box<dyn Error>> {
         self.call_method("ConnectProfile", Some(&[uuid.into()]), 30000)
     }
 
-    // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n55
+    // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n73
     pub fn disconnect_profile(&self, uuid: String) -> Result<Message, Box<dyn Error>> {
         self.call_method("DisconnectProfile", Some(&[uuid.into()]), 5000)
     }
 
-    // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n70
+    // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n88
     pub fn pair(&self, timeout_ms: i32) -> Result<Message, Box<dyn Error>> {
         self.call_method("Pair", None, timeout_ms)
     }
 
-    // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n97
+    // http://git.kernel.org/cgit/bluetooth/bluez.git/tree/doc/device-api.txt#n115
     pub fn cancel_pairing(&self) -> Result<Message, Box<dyn Error>> {
         self.call_method("CancelPairing", None, 5000)
     }

--- a/src/bluetooth_discovery_session.rs
+++ b/src/bluetooth_discovery_session.rs
@@ -1,5 +1,6 @@
 use crate::bluetooth_session::BluetoothSession;
-use dbus::{Message, MessageItem, MessageItemArray, Signature};
+use dbus::Message;
+use dbus::arg::messageitem::MessageItem;
 use std::error::Error;
 
 static ADAPTER_INTERFACE: &str = "org.bluez.Adapter1";
@@ -63,32 +64,30 @@ impl<'a> BluetoothDiscoverySession<'a> {
             res
         };
 
-        let mut m = vec![MessageItem::DictEntry(
-            Box::new("UUIDs".into()),
-            Box::new(MessageItem::Variant(Box::new(
+        let mut m = vec![(
+            "UUIDs".into(),
+            MessageItem::Variant(Box::new(
                 MessageItem::new_array(uuids).unwrap(),
-            ))),
+            )),
         )];
 
         if let Some(rssi) = rssi {
-            m.push(MessageItem::DictEntry(
-                Box::new("RSSI".into()),
-                Box::new(MessageItem::Variant(Box::new(rssi.into()))),
+            m.push((
+                "RSSI".into(),
+                MessageItem::Variant(Box::new(rssi.into())),
             ))
         }
 
         if let Some(pathloss) = pathloss {
-            m.push(MessageItem::DictEntry(
-                Box::new("Pathloss".into()),
-                Box::new(MessageItem::Variant(Box::new(pathloss.into()))),
+            m.push((
+                "Pathloss".into(),
+                MessageItem::Variant(Box::new(pathloss.into())),
             ))
         }
 
         self.call_method(
             "SetDiscoveryFilter",
-            Some([MessageItem::Array(
-                MessageItemArray::new(m, Signature::from("a{sv}")).unwrap(),
-            )]),
+            Some([MessageItem::new_dict(m).unwrap()]),
         )
     }
 }

--- a/src/bluetooth_gatt_descriptor.rs
+++ b/src/bluetooth_gatt_descriptor.rs
@@ -1,9 +1,12 @@
 use crate::bluetooth_session::BluetoothSession;
 use crate::bluetooth_utils;
 use crate::bluetooth_event::BluetoothEvent;
-use dbus::{BusType, Connection, Message, MessageItem, MessageItemArray, Signature};
+use dbus::{Message, Signature};
+use dbus::ffidisp::{Connection, BusType};
+use dbus::arg::messageitem::{MessageItem, MessageItemDict};
 
 use std::error::Error;
+use dbus::arg::Variant;
 
 static SERVICE_NAME: &str = "org.bluez";
 static GATT_DESCRIPTOR_INTERFACE: &str = "org.bluez.GattDescriptor1";
@@ -102,16 +105,17 @@ impl<'a> BluetoothGATTDescriptor<'a> {
             GATT_DESCRIPTOR_INTERFACE,
             "ReadValue"
         )?;
-        m.append_items(&[MessageItem::Array(
-            MessageItemArray::new(
+        m.append_items(&[MessageItem::Dict(
+            MessageItemDict::new(
                 match offset {
-                    Some(o) => vec![MessageItem::DictEntry(
-                        Box::new("offset".into()),
-                        Box::new(MessageItem::Variant(Box::new(o.into()))),
+                    Some(o) => vec![(
+                        "offset".into(),
+                        MessageItem::Variant(Box::new(o.into())),
                     )],
                     None => vec![],
                 },
-                Signature::from("a{sv}"),
+                Signature::make::<String>(),
+                Signature::make::<Variant<u8>>(),
             ).unwrap(),
         )]);
         let reply = c.send_with_reply_and_block(m, 1000)?;
@@ -136,16 +140,17 @@ impl<'a> BluetoothGATTDescriptor<'a> {
             "WriteValue",
             Some(&[
                 MessageItem::new_array(args).unwrap(),
-                MessageItem::Array(
-                    MessageItemArray::new(
+                MessageItem::Dict(
+                    MessageItemDict::new(
                         match offset {
-                            Some(o) => vec![MessageItem::DictEntry(
-                                Box::new("offset".into()),
-                                Box::new(MessageItem::Variant(Box::new(o.into()))),
+                            Some(o) => vec![(
+                                "offset".into(),
+                                MessageItem::Variant(Box::new(o.into())),
                             )],
                             None => vec![],
                         },
-                        Signature::from("a{sv}"),
+                        Signature::make::<String>(),
+                        Signature::make::<Variant<u8>>(),
                     ).unwrap(),
                 ),
             ]),

--- a/src/bluetooth_gatt_service.rs
+++ b/src/bluetooth_gatt_service.rs
@@ -1,6 +1,6 @@
 use crate::bluetooth_session::BluetoothSession;
 use crate::bluetooth_utils;
-use dbus::MessageItem;
+use dbus::arg::messageitem::MessageItem;
 
 use std::error::Error;
 

--- a/src/bluetooth_le_advertising_data.rs
+++ b/src/bluetooth_le_advertising_data.rs
@@ -1,6 +1,6 @@
 use crate::bluetooth_utils;
 use crate::bluetooth_session::BluetoothSession;
-use dbus::MessageItem;
+use dbus::arg::messageitem::MessageItem;
 use std::collections::HashMap;
 use std::error::Error;
 

--- a/src/bluetooth_le_advertising_manager.rs
+++ b/src/bluetooth_le_advertising_manager.rs
@@ -1,6 +1,8 @@
 use crate::bluetooth_utils;
 use std::error::Error;
-use dbus::{Connection, BusType, Message, MessageItem};
+use dbus::Message;
+use dbus::ffidisp::{Connection, BusType};
+use dbus::arg::messageitem::MessageItem;
 
 static LEADVERTISING_MANAGER_INTERFACE: &'static str = "org.bluez.LEAdvertisingManager1";
 

--- a/src/bluetooth_obex.rs
+++ b/src/bluetooth_obex.rs
@@ -1,7 +1,7 @@
 extern crate dbus;
 use self::dbus::arg::{Dict, Variant};
 use self::dbus::Path as ObjectPath;
-use self::dbus::{BusType, Connection, Message, MessageItem, Props};
+use self::dbus::Message;
 use std::collections::HashMap;
 use std::error::Error;
 use std::path::Path;
@@ -10,6 +10,8 @@ use std::time::Duration;
 
 use crate::bluetooth_device::BluetoothDevice;
 use crate::bluetooth_session::BluetoothSession;
+use dbus::ffidisp::{Connection, BusType};
+use dbus::arg::messageitem::{MessageItem, Props};
 
 const OBEX_BUS: &str = "org.bluez.obex";
 const OBEX_PATH: &str = "/org/bluez/obex";
@@ -76,7 +78,7 @@ impl<'a> BluetoothOBEXSession<'a> {
         let device_address: String = device.get_address()?;
         let mut map = HashMap::new();
         map.insert("Target", Variant(SessionTarget::Opp.as_str()));
-        let args: Dict<&str, Variant<&str>, _> = Dict::new(map);
+        let args = Dict::new(&map);
         let m = Message::new_method_call(OBEX_BUS, OBEX_PATH, CLIENT_INTERFACE, "CreateSession")?
             .append2(device_address, args);
 
@@ -94,7 +96,7 @@ impl<'a> BluetoothOBEXSession<'a> {
 
     // https://git.kernel.org/pub/scm/bluetooth/bluez.git/tree/doc/obex-api.txt#n35
     pub fn remove_session(&self) -> Result<(), Box<dyn Error>> {
-        let object_path = ObjectPath::new(self.object_path.as_bytes())?;
+        let object_path = ObjectPath::new(self.object_path.as_str())?;
         let m = Message::new_method_call(OBEX_BUS, OBEX_PATH, CLIENT_INTERFACE, "RemoveSession")?
             .append1(object_path);
         let _r = self

--- a/src/bluetooth_session.rs
+++ b/src/bluetooth_session.rs
@@ -1,5 +1,4 @@
-use dbus::{BusType, ConnMsgs, Connection};
-
+use dbus::ffidisp::{Connection, BusType, ConnMsgs};
 use std::error::Error;
 
 static BLUEZ_MATCH: &str = "type='signal',sender='org.bluez'";

--- a/src/bluetooth_utils.rs
+++ b/src/bluetooth_utils.rs
@@ -1,4 +1,6 @@
-use dbus::{BusType, Connection, Message, MessageItem, Props};
+use dbus::arg::messageitem::{MessageItem, Props};
+use dbus::ffidisp::{Connection, BusType};
+use dbus::Message;
 use std::error::Error;
 
 static ADAPTER_INTERFACE: &str = "org.bluez.Adapter1";
@@ -24,12 +26,10 @@ fn get_managed_objects(c: &Connection) -> Result<Vec<MessageItem>, Box<dyn Error
 pub fn get_adapters(c: &Connection) -> Result<Vec<String>, Box<dyn Error>> {
     let mut adapters: Vec<String> = Vec::new();
     let objects: Vec<MessageItem> = get_managed_objects(&c)?;
-    let z: &[MessageItem] = objects.get(0).unwrap().inner().unwrap();
-    for y in z {
-        let (path, interfaces) = y.inner().unwrap();
-        let x: &[MessageItem] = interfaces.inner().unwrap();
-        for interface in x {
-            let (i, _) = interface.inner().unwrap();
+    let z: &[(MessageItem, MessageItem)] = objects.get(0).unwrap().inner().unwrap();
+    for (path, interfaces) in z {
+        let x: &[(MessageItem, MessageItem)] = interfaces.inner().unwrap();
+        for (i, _) in x {
             let name: &str = i.inner().unwrap();
             if name == ADAPTER_INTERFACE {
                 let p: &str = path.inner().unwrap();
@@ -44,12 +44,10 @@ pub fn get_ad_man() -> Result<Vec<String>, Box<dyn Error>> {
     let mut managers: Vec<String> = Vec::new();
     let c = Connection::get_private(BusType::System)?;
     let objects: Vec<MessageItem> = get_managed_objects(&c)?;
-    let z: &[MessageItem] = objects.get(0).unwrap().inner().unwrap();
-    for y in z {
-        let (path, interfaces) = y.inner().unwrap();
-        let x: &[MessageItem] = interfaces.inner().unwrap();
-        for interface in x {
-            let (i,_) = interface.inner().unwrap();
+    let z: &[(MessageItem, MessageItem)] = objects.get(0).unwrap().inner().unwrap();
+    for (path, interfaces) in z {
+        let x: &[(MessageItem, MessageItem)] = interfaces.inner().unwrap();
+        for (i, _) in x {
             let name: &str = i.inner().unwrap();
             if name == LEADVERTISING_MANAGER_INTERFACE {
                 let p: &str = path.inner().unwrap();
@@ -96,12 +94,10 @@ fn list_item(
 
     let mut v: Vec<String> = Vec::new();
     let objects: Vec<MessageItem> = get_managed_objects(&c)?;
-    let z: &[MessageItem] = objects.get(0).unwrap().inner().unwrap();
-    for y in z {
-        let (path, interfaces) = y.inner().unwrap();
-        let x: &[MessageItem] = interfaces.inner().unwrap();
-        for interface in x {
-            let (i, _) = interface.inner().unwrap();
+    let z: &[(MessageItem, MessageItem)] = objects.get(0).unwrap().inner().unwrap();
+    for (path, interfaces) in z {
+        let x: &[(MessageItem, MessageItem)] = interfaces.inner().unwrap();
+        for (i, _) in x {
             let name: &str = i.inner().unwrap();
             if name == item_interface {
                 let objpath: &str = path.inner().unwrap();


### PR DESCRIPTION
Update to dbus 0.9.0

This still uses the old ffi implementation. The documentation recommends to migrate to the new implementation.


This fork is the most maintained, and I have been using it for development. Rebasing the change on szeged upstream would have been much unnecessary work, including using Rust edition 2015.

I would have filed an issue to ask if you're accepting pull requests, but they are disabled for the project. Perhaps you would be willing to bundle development on your fork, until a more permanent solution can be found (e.g. changes can be merged back to upstream, crates project transferred, etc.)? See https://github.com/szeged/blurz/issues/32